### PR TITLE
Update for Ruby 3.0

### DIFF
--- a/lib/workarea/avatax/version.rb
+++ b/lib/workarea/avatax/version.rb
@@ -1,5 +1,5 @@
 module Workarea
   module Avatax
-    VERSION = '4.3.0'
+    VERSION = '4.4.0'
   end
 end

--- a/workarea-avatax.gemspec
+++ b/workarea-avatax.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   s.add_dependency 'workarea', '>= 3.5.x'
-  s.add_dependency "avatax", "~> 18.12.0"
+  s.add_dependency "avatax", "~> 21.10.0"
   s.add_dependency "hashie", "~> 3.0"
 end


### PR DESCRIPTION
Updates the avatax gem version for Ruby 3.0 compatibility and bumps the minor version.